### PR TITLE
Primitive functions for double + long

### DIFF
--- a/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
  * @since 1.5.0
  */
 @FunctionalInterface
-interface ThrowingDoubleFunction<R, E extends Exception> {
+public interface ThrowingDoubleFunction<R, E extends Exception> {
 
     R apply(double d) throws E;
 

--- a/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
@@ -1,0 +1,69 @@
+package com.pivovarit.function;
+
+import com.pivovarit.function.exception.WrappedException;
+
+import java.util.Optional;
+import java.util.function.LongFunction;
+
+import static com.pivovarit.function.SneakyThrowUtil.sneakyThrow;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Functional interface mirroring {@link LongFunction<R>} for primitive longs from the java.util.function package.
+ * This allows wrapping a exceptions in a runtime exception: {@link WrappedException}
+ * <p>
+ * As this adheres to the {@link LongFunction} interface, compose and andThen (as you might be familiar with from
+ * {@link java.util.function.Function} are not available.
+ *
+ * @param <R> the type of the result of the function
+ * @param <E> the type of the thrown checked exception
+ * @since 1.5.0
+ */
+@FunctionalInterface
+interface ThrowingLongFunction<R, E extends Exception> {
+
+    R apply(long l) throws E;
+
+    default LongFunction<R> uncheck() {
+        return t -> {
+            try {
+                return apply(t);
+            } catch (final Exception e) {
+                throw new WrappedException(e);
+            }
+        };
+    }
+
+    static <R> LongFunction<R> unchecked(final ThrowingLongFunction<R, ?> f) {
+        return requireNonNull(f).uncheck();
+    }
+
+    /**
+     * @return a Function that returns the result of the given function as an Optional instance.
+     * In case of a failure, empty Optional is returned
+     */
+    static <R> LongFunction<Optional<R>> lifted(final ThrowingLongFunction<R, ?> f) {
+        return requireNonNull(f).lift();
+    }
+
+    static <R> LongFunction<R> sneaky(ThrowingLongFunction<? extends R, ?> function) {
+        requireNonNull(function);
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (final Exception ex) {
+                return sneakyThrow(ex);
+            }
+        };
+    }
+
+    default LongFunction<Optional<R>> lift() {
+        return t -> {
+            try {
+                return Optional.ofNullable(apply(t));
+            } catch (final Exception e) {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingDoubleFunction.java
@@ -3,16 +3,16 @@ package com.pivovarit.function;
 import com.pivovarit.function.exception.WrappedException;
 
 import java.util.Optional;
-import java.util.function.LongFunction;
+import java.util.function.DoubleFunction;
 
 import static com.pivovarit.function.SneakyThrowUtil.sneakyThrow;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Functional interface mirroring {@link LongFunction<R>} for primitive longs from the java.util.function package.
+ * Functional interface mirroring {@link DoubleFunction<R>} for primitive doubles from the java.util.function package.
  * This allows wrapping a exceptions in a runtime exception: {@link WrappedException}
  * <p>
- * As this adheres to the {@link LongFunction} interface, compose and andThen (as you might be familiar with from
+ * As this adheres to the {@link DoubleFunction} interface, compose and andThen (as you might be familiar with from
  * {@link java.util.function.Function} are not available.
  *
  * @param <R> the type of the result of the function
@@ -20,11 +20,11 @@ import static java.util.Objects.requireNonNull;
  * @since 1.5.0
  */
 @FunctionalInterface
-interface ThrowingLongFunction<R, E extends Exception> {
+interface ThrowingDoubleFunction<R, E extends Exception> {
 
-    R apply(long l) throws E;
+    R apply(double d) throws E;
 
-    default LongFunction<R> uncheck() {
+    default DoubleFunction<R> uncheck() {
         return t -> {
             try {
                 return apply(t);
@@ -34,7 +34,7 @@ interface ThrowingLongFunction<R, E extends Exception> {
         };
     }
 
-    static <R> LongFunction<R> unchecked(final ThrowingLongFunction<R, ?> f) {
+    static <R> DoubleFunction<R> unchecked(final ThrowingDoubleFunction<R, ?> f) {
         return requireNonNull(f).uncheck();
     }
 
@@ -42,11 +42,11 @@ interface ThrowingLongFunction<R, E extends Exception> {
      * @return a Function that returns the result of the given function as an Optional instance.
      * In case of a failure, empty Optional is returned
      */
-    static <R> LongFunction<Optional<R>> lifted(final ThrowingLongFunction<R, ?> f) {
+    static <R> DoubleFunction<Optional<R>> lifted(final ThrowingDoubleFunction<R, ?> f) {
         return requireNonNull(f).lift();
     }
 
-    static <R> LongFunction<R> sneaky(ThrowingLongFunction<? extends R, ?> function) {
+    static <R> DoubleFunction<R> sneaky(ThrowingDoubleFunction<? extends R, ?> function) {
         requireNonNull(function);
         return t -> {
             try {
@@ -57,7 +57,7 @@ interface ThrowingLongFunction<R, E extends Exception> {
         };
     }
 
-    default LongFunction<Optional<R>> lift() {
+    default DoubleFunction<Optional<R>> lift() {
         return t -> {
             try {
                 return Optional.ofNullable(apply(t));

--- a/src/main/java/com/pivovarit/function/ThrowingIntFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingIntFunction.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
  * @since 1.5.0
  */
 @FunctionalInterface
-interface ThrowingIntFunction<R, E extends Exception> {
+public interface ThrowingIntFunction<R, E extends Exception> {
 
     R apply(int i) throws E;
 

--- a/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
  * @since 1.5.0
  */
 @FunctionalInterface
-interface ThrowingLongFunction<R, E extends Exception> {
+public interface ThrowingLongFunction<R, E extends Exception> {
 
     R apply(long l) throws E;
 

--- a/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
@@ -1,0 +1,4 @@
+package com.pivovarit.function;
+
+public class ThrowingLongFunction {
+}

--- a/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
+++ b/src/main/java/com/pivovarit/function/ThrowingLongFunction.java
@@ -1,4 +1,69 @@
 package com.pivovarit.function;
 
-public class ThrowingLongFunction {
+import com.pivovarit.function.exception.WrappedException;
+
+import java.util.Optional;
+import java.util.function.LongFunction;
+
+import static com.pivovarit.function.SneakyThrowUtil.sneakyThrow;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Functional interface mirroring {@link LongFunction<R>} for primitive longs from the java.util.function package.
+ * This allows wrapping a exceptions in a runtime exception: {@link WrappedException}
+ * <p>
+ * As this adheres to the {@link LongFunction} interface, compose and andThen (as you might be familiar with from
+ * {@link java.util.function.Function} are not available.
+ *
+ * @param <R> the type of the result of the function
+ * @param <E> the type of the thrown checked exception
+ * @since 1.5.0
+ */
+@FunctionalInterface
+interface ThrowingLongFunction<R, E extends Exception> {
+
+    R apply(long l) throws E;
+
+    default LongFunction<R> uncheck() {
+        return t -> {
+            try {
+                return apply(t);
+            } catch (final Exception e) {
+                throw new WrappedException(e);
+            }
+        };
+    }
+
+    static <R> LongFunction<R> unchecked(final ThrowingLongFunction<R, ?> f) {
+        return requireNonNull(f).uncheck();
+    }
+
+    /**
+     * @return a Function that returns the result of the given function as an Optional instance.
+     * In case of a failure, empty Optional is returned
+     */
+    static <R> LongFunction<Optional<R>> lifted(final ThrowingLongFunction<R, ?> f) {
+        return requireNonNull(f).lift();
+    }
+
+    static <R> LongFunction<R> sneaky(ThrowingLongFunction<? extends R, ?> function) {
+        requireNonNull(function);
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (final Exception ex) {
+                return sneakyThrow(ex);
+            }
+        };
+    }
+
+    default LongFunction<Optional<R>> lift() {
+        return t -> {
+            try {
+                return Optional.ofNullable(apply(t));
+            } catch (final Exception e) {
+                return Optional.empty();
+            }
+        };
+    }
 }

--- a/src/test/java/com/pivovarit/function/ThrowingBiConsumerTest.java
+++ b/src/test/java/com/pivovarit/function/ThrowingBiConsumerTest.java
@@ -13,7 +13,7 @@ class ThrowingBiConsumerTest {
 
     @Test
     void givenString_whenSortJava8_thenSorted() {
-        String sorted = "bdCa".chars()
+        String sorted = "bdca".chars()
           .sorted()
           .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
           .toString();

--- a/src/test/java/com/pivovarit/function/ThrowingDoubleFunctionTest.java
+++ b/src/test/java/com/pivovarit/function/ThrowingDoubleFunctionTest.java
@@ -1,0 +1,79 @@
+package com.pivovarit.function;
+
+import com.pivovarit.function.exception.WrappedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static com.pivovarit.function.ThrowingIntFunction.lifted;
+import static com.pivovarit.function.ThrowingIntFunction.unchecked;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ThrowingIntFunctionTest {
+
+    private static final String EXPECTED_MESSAGE = "Oh no! " + UUID.randomUUID();
+    private static final ThrowingIntFunction<String, Exception> THROWS_CHECKED = i -> {
+        throw new Exception(EXPECTED_MESSAGE);
+    };
+
+    @Test
+    void shouldReturnOptional() {
+        ThrowingIntFunction<String, Exception> f = Integer::toString;
+
+        Optional<String> result = f.lift().apply(42);
+
+        assertThat(result).isEqualTo(Optional.of("42"));
+    }
+
+    @Test
+    void shouldReturnEmptyOptional() {
+        Optional<String> result = THROWS_CHECKED.lift().apply(42);
+
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    @Test
+    void shouldThrowEx() {
+        assertThatThrownBy(() -> THROWS_CHECKED.apply(42))
+                .isInstanceOf(Exception.class)
+                .hasMessage(EXPECTED_MESSAGE);
+    }
+
+    @Test
+    void shouldWrapInRuntimeEx() {
+        assertThatThrownBy(() -> THROWS_CHECKED.uncheck().apply(42))
+                .isInstanceOf(WrappedException.class)
+                .hasMessage(EXPECTED_MESSAGE);
+    }
+
+
+    @Test
+    void shouldWrapInRuntimeExWhenUsingUnchecked() {
+        assertThatThrownBy(() -> IntStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
+                .isInstanceOf(WrappedException.class)
+                .hasMessage(EXPECTED_MESSAGE)
+                .hasCauseInstanceOf(Exception.class);
+    }
+
+    @Test
+    void shouldApplyWhenNoExceptionThrown() {
+        ThrowingIntFunction<String, Exception> f = Integer::toString;
+
+        List<String> result = IntStream.of(42, 256).mapToObj(f.uncheck()).collect(toList());
+
+        assertThat(result).containsExactly("42", "256");
+    }
+
+    @Test
+    void shouldWrapInOptionalWhenUsingStandardUtilsFunctions() {
+        Long result = IntStream.of(42).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
+
+        assertThat(result).isZero();
+    }
+
+}

--- a/src/test/java/com/pivovarit/function/ThrowingDoubleFunctionTest.java
+++ b/src/test/java/com/pivovarit/function/ThrowingDoubleFunctionTest.java
@@ -6,47 +6,47 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.IntStream;
+import java.util.stream.DoubleStream;
 
-import static com.pivovarit.function.ThrowingIntFunction.lifted;
-import static com.pivovarit.function.ThrowingIntFunction.unchecked;
+import static com.pivovarit.function.ThrowingDoubleFunction.lifted;
+import static com.pivovarit.function.ThrowingDoubleFunction.unchecked;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class ThrowingIntFunctionTest {
+class ThrowingDoubleFunctionTest {
 
     private static final String EXPECTED_MESSAGE = "Oh no! " + UUID.randomUUID();
-    private static final ThrowingIntFunction<String, Exception> THROWS_CHECKED = i -> {
+    private static final ThrowingDoubleFunction<String, Exception> THROWS_CHECKED = i -> {
         throw new Exception(EXPECTED_MESSAGE);
     };
 
     @Test
     void shouldReturnOptional() {
-        ThrowingIntFunction<String, Exception> f = Integer::toString;
+        ThrowingDoubleFunction<String, Exception> f = Double::toString;
 
-        Optional<String> result = f.lift().apply(42);
+        Optional<String> result = f.lift().apply(42.0);
 
-        assertThat(result).isEqualTo(Optional.of("42"));
+        assertThat(result).isEqualTo(Optional.of("42.0"));
     }
 
     @Test
     void shouldReturnEmptyOptional() {
-        Optional<String> result = THROWS_CHECKED.lift().apply(42);
+        Optional<String> result = THROWS_CHECKED.lift().apply(42.0);
 
         assertThat(result.isPresent()).isFalse();
     }
 
     @Test
     void shouldThrowEx() {
-        assertThatThrownBy(() -> THROWS_CHECKED.apply(42))
+        assertThatThrownBy(() -> THROWS_CHECKED.apply(42.0))
                 .isInstanceOf(Exception.class)
                 .hasMessage(EXPECTED_MESSAGE);
     }
 
     @Test
     void shouldWrapInRuntimeEx() {
-        assertThatThrownBy(() -> THROWS_CHECKED.uncheck().apply(42))
+        assertThatThrownBy(() -> THROWS_CHECKED.uncheck().apply(42.0))
                 .isInstanceOf(WrappedException.class)
                 .hasMessage(EXPECTED_MESSAGE);
     }
@@ -54,7 +54,7 @@ class ThrowingIntFunctionTest {
 
     @Test
     void shouldWrapInRuntimeExWhenUsingUnchecked() {
-        assertThatThrownBy(() -> IntStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
+        assertThatThrownBy(() -> DoubleStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
                 .isInstanceOf(WrappedException.class)
                 .hasMessage(EXPECTED_MESSAGE)
                 .hasCauseInstanceOf(Exception.class);
@@ -62,16 +62,16 @@ class ThrowingIntFunctionTest {
 
     @Test
     void shouldApplyWhenNoExceptionThrown() {
-        ThrowingIntFunction<String, Exception> f = Integer::toString;
+        ThrowingDoubleFunction<String, Exception> f = Double::toString;
 
-        List<String> result = IntStream.of(42, 256).mapToObj(f.uncheck()).collect(toList());
+        List<String> result = DoubleStream.of(42.0, 256).mapToObj(f.uncheck()).collect(toList());
 
-        assertThat(result).containsExactly("42", "256");
+        assertThat(result).containsExactly("42.0", "256.0");
     }
 
     @Test
     void shouldWrapInOptionalWhenUsingStandardUtilsFunctions() {
-        Long result = IntStream.of(42).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
+        Long result = DoubleStream.of(42.0).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
 
         assertThat(result).isZero();
     }

--- a/src/test/java/com/pivovarit/function/ThrowingLongFunctionTest.java
+++ b/src/test/java/com/pivovarit/function/ThrowingLongFunctionTest.java
@@ -6,24 +6,24 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
-import static com.pivovarit.function.ThrowingIntFunction.lifted;
-import static com.pivovarit.function.ThrowingIntFunction.unchecked;
+import static com.pivovarit.function.ThrowingLongFunction.lifted;
+import static com.pivovarit.function.ThrowingLongFunction.unchecked;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class ThrowingIntFunctionTest {
+class ThrowingLongFunctionTest {
 
     private static final String EXPECTED_MESSAGE = "Oh no! " + UUID.randomUUID();
-    private static final ThrowingIntFunction<String, Exception> THROWS_CHECKED = i -> {
+    private static final ThrowingLongFunction<String, Exception> THROWS_CHECKED = i -> {
         throw new Exception(EXPECTED_MESSAGE);
     };
 
     @Test
     void shouldReturnOptional() {
-        ThrowingIntFunction<String, Exception> f = Integer::toString;
+        ThrowingLongFunction<String, Exception> f = Long::toString;
 
         Optional<String> result = f.lift().apply(42);
 
@@ -54,7 +54,7 @@ class ThrowingIntFunctionTest {
 
     @Test
     void shouldWrapInRuntimeExWhenUsingUnchecked() {
-        assertThatThrownBy(() -> IntStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
+        assertThatThrownBy(() -> LongStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
                 .isInstanceOf(WrappedException.class)
                 .hasMessage(EXPECTED_MESSAGE)
                 .hasCauseInstanceOf(Exception.class);
@@ -62,16 +62,16 @@ class ThrowingIntFunctionTest {
 
     @Test
     void shouldApplyWhenNoExceptionThrown() {
-        ThrowingIntFunction<String, Exception> f = Integer::toString;
+        ThrowingLongFunction<String, Exception> f = Long::toString;
 
-        List<String> result = IntStream.of(42, 256).mapToObj(f.uncheck()).collect(toList());
+        List<String> result = LongStream.of(42, 256).mapToObj(f.uncheck()).collect(toList());
 
         assertThat(result).containsExactly("42", "256");
     }
 
     @Test
     void shouldWrapInOptionalWhenUsingStandardUtilsFunctions() {
-        Long result = IntStream.of(42).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
+        Long result = LongStream.of(42).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
 
         assertThat(result).isZero();
     }

--- a/src/test/java/com/pivovarit/function/ThrowingLongFunctionTest.java
+++ b/src/test/java/com/pivovarit/function/ThrowingLongFunctionTest.java
@@ -1,0 +1,79 @@
+package com.pivovarit.function;
+
+import com.pivovarit.function.exception.WrappedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static com.pivovarit.function.ThrowingIntFunction.lifted;
+import static com.pivovarit.function.ThrowingIntFunction.unchecked;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ThrowingIntFunctionTest {
+
+    private static final String EXPECTED_MESSAGE = "Oh no! " + UUID.randomUUID();
+    private static final ThrowingIntFunction<String, Exception> THROWS_CHECKED = i -> {
+        throw new Exception(EXPECTED_MESSAGE);
+    };
+
+    @Test
+    void shouldReturnOptional() {
+        ThrowingIntFunction<String, Exception> f = Integer::toString;
+
+        Optional<String> result = f.lift().apply(42);
+
+        assertThat(result).isEqualTo(Optional.of("42"));
+    }
+
+    @Test
+    void shouldReturnEmptyOptional() {
+        Optional<String> result = THROWS_CHECKED.lift().apply(42);
+
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    @Test
+    void shouldThrowEx() {
+        assertThatThrownBy(() -> THROWS_CHECKED.apply(42))
+                .isInstanceOf(Exception.class)
+                .hasMessage(EXPECTED_MESSAGE);
+    }
+
+    @Test
+    void shouldWrapInRuntimeEx() {
+        assertThatThrownBy(() -> THROWS_CHECKED.uncheck().apply(42))
+                .isInstanceOf(WrappedException.class)
+                .hasMessage(EXPECTED_MESSAGE);
+    }
+
+
+    @Test
+    void shouldWrapInRuntimeExWhenUsingUnchecked() {
+        assertThatThrownBy(() -> IntStream.of(1).mapToObj(unchecked(THROWS_CHECKED)).count())
+                .isInstanceOf(WrappedException.class)
+                .hasMessage(EXPECTED_MESSAGE)
+                .hasCauseInstanceOf(Exception.class);
+    }
+
+    @Test
+    void shouldApplyWhenNoExceptionThrown() {
+        ThrowingIntFunction<String, Exception> f = Integer::toString;
+
+        List<String> result = IntStream.of(42, 256).mapToObj(f.uncheck()).collect(toList());
+
+        assertThat(result).containsExactly("42", "256");
+    }
+
+    @Test
+    void shouldWrapInOptionalWhenUsingStandardUtilsFunctions() {
+        Long result = IntStream.of(42).mapToObj(lifted(THROWS_CHECKED)).filter(Optional::isPresent).count();
+
+        assertThat(result).isZero();
+    }
+
+}


### PR DESCRIPTION
Duplicated the ThrowingIntFunction + corresponding test and replaced int with double and long.

There was a failing test when executing the entire test suite - was this intentional? I've kept it as a separate commit.