### PR TITLE
Import designated packaged and not the whole classpath when applying arch-unit rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>

--- a/src/test/java/com/pivovarit/function/ArchitectureTest.java
+++ b/src/test/java/com/pivovarit/function/ArchitectureTest.java
@@ -29,10 +29,7 @@ class ArchitectureTest {
       .because("users appreciate not experiencing a dependency hell");
 
     private static final JavaClasses classes = new ClassFileImporter()
-      .importClasspath(new ImportOptions()
-        .with(DO_NOT_INCLUDE_JARS)
-        .with(DO_NOT_INCLUDE_ARCHIVES)
-        .with(DO_NOT_INCLUDE_TESTS));
+      .importPackages("com.pivovarit");
 
     @Test
     void shouldHavePublicInterfacesWithCorrectNamingPattern() {


### PR DESCRIPTION
Fixes: https://github.com/pivovarit/throwing-function/issues/89