### PR TITLE
Add module info to final jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,33 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>com.pivovarit.function</name>
+                                    <exports>
+                                        com.pivovarit.function;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This adds a module-info to the final jar under `META-INF/versions/9`. It will not affect compatibility with Java 8

This will enable downstream libraries (i'm looking at https://github.com/bbottema/simple-java-mail now) to have module infos of their own and for consumers to use `jlink`. 