### PR TITLE
Add explicit module definition to a multi-release jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,33 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.0</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>com.pivovarit.function</name>
+                                    <exports>
+                                        com.pivovarit.function;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@
                         </manifest>
                         <manifestEntries>
                             <Build-Time>${maven.build.timestamp}</Build-Time>
-                            <Automatic-Module-Name>com.pivovarit.function</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -201,12 +200,11 @@
                         <configuration>
                             <jvmVersion>9</jvmVersion>
                             <module>
-                                <moduleInfo>
-                                    <name>com.pivovarit.function</name>
-                                    <exports>
-                                        com.pivovarit.function;
-                                    </exports>
-                                </moduleInfo>
+                                <moduleInfoSource>
+                                    module com.pivovarit.function {
+                                        exports com.pivovarit.function;
+                                    }
+                                </moduleInfoSource>
                             </module>
                             <overwriteExistingFiles>true</overwriteExistingFiles>
                         </configuration>


### PR DESCRIPTION
This adds a module-info to the final jar under `META-INF/versions/9`. It will not affect compatibility with Java 8

This will enable downstream libraries (I'm looking at https://github.com/bbottema/simple-java-mail now) to have module infos of their own and for consumers to use `jlink`. 